### PR TITLE
Update security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,8 +5,8 @@ on:
     branches: [ dev, staging ]
     tags: [ 'v*.*.*' ]
   workflow_dispatch: 
-  #schedule:
-  # - cron: '00 9 * * 1,3,5'
+  schedule:
+    - cron: '00 9 * * 1,3,5'
 
 jobs:
   container-scan:
@@ -28,7 +28,7 @@ jobs:
           dockerfile: Dockerfile
           output_path: ./output/hazard-report.html
           cleanup_path: /data/watchtower/ctx-API/container-results/api-hazard/hazard-report.html
-          watchtower_path: /data/watchtower/ctx-API/container-results/api-hazard/hazard-report.html
+          watchtower_path: /data/watchtower/ctx-API/container-results/api-hazard
 
   trufflehog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary of change
- Added a scheduled (cron) trigger to the security.yml workflow so trivy scan runs automatically on a recurring basis, ensuring we always have a current scan report rather than only scanning on push.
- Updated watchtower-path for sending trivy report
- Changes confined to security.yml